### PR TITLE
SimpleWebSocketClient:

### DIFF
--- a/client/src/main/scala/client/SimpleWebSocketClient.scala
+++ b/client/src/main/scala/client/SimpleWebSocketClient.scala
@@ -48,7 +48,7 @@ final class SimpleWebSocketClient private (url: String, os: OverflowStrategy.Syn
 
         webSocket.onerror = (event: ErrorEvent) => {
           // If error, signal it and it will be the last message
-          downstream.onError(BackPressuredWebSocketClient.Exception(event.message))
+          downstream.onError(SimpleWebSocketClient.Exception(event.message))
         }
         webSocket.onclose = (event: CloseEvent) => {
           // If close, signal it and it will be the last message
@@ -83,18 +83,14 @@ final class SimpleWebSocketClient private (url: String, os: OverflowStrategy.Syn
 
       def onError(ex: Throwable): Unit = {
         scheduler.reportFailure(ex)
-        // Retry connection in a couple of secs
-        self
-          .delaySubscription(3.seconds)
-          .unsafeSubscribeFn(subscriber)
+        onComplete()
       }
 
-      def onComplete(): Unit = {
+      def onComplete(): Unit =
         // Retry connection in a couple of secs
         self
           .delaySubscription(3.seconds)
           .unsafeSubscribeFn(subscriber)
-      }
     })
 }
 

--- a/server/app/controllers/ApplicationController.scala
+++ b/server/app/controllers/ApplicationController.scala
@@ -7,16 +7,12 @@ import monix.execution.Scheduler.Implicits.global
 import play.api.Environment
 import play.api.libs.json.JsValue
 import play.api.libs.streams.ActorFlow
-import play.api.mvc.WebSocket.MessageFlowTransformer
 import play.api.mvc._
 import scala.concurrent.duration._
 
 class ApplicationController()
   (implicit env: Environment, as: ActorSystem, m: Materializer)
   extends Controller with JSONFormats {
-
-  implicit val messageFlowTransformer =
-    MessageFlowTransformer.jsonMessageFlowTransformer[JsValue, JsValue]
 
   def index = Action {
     Ok(views.html.index(env))

--- a/server/app/engine/BackPressuredWebSocketActor.scala
+++ b/server/app/engine/BackPressuredWebSocketActor.scala
@@ -8,13 +8,12 @@ import monix.execution.rstreams.SingleAssignmentSubscription
 import monix.reactive.Observable
 import org.reactivestreams.{Subscriber, Subscription}
 import play.api.libs.json._
-import shared.models.Event
 
 import scala.concurrent.duration._
 import scala.util.Try
 
 
-class BackPressuredWebSocketActor[T <: Event : Writes]
+class BackPressuredWebSocketActor[T: Writes]
   (producer: Observable[T], out: ActorRef)(implicit s: Scheduler)
   extends Actor with LazyLogging {
 
@@ -76,7 +75,7 @@ class BackPressuredWebSocketActor[T <: Event : Writes]
 
 object BackPressuredWebSocketActor {
   /** Utility for quickly creating a `Props` */
-  def props[T <: Event : Writes](producer: Observable[T], out: ActorRef)
+  def props[T: Writes](producer: Observable[T], out: ActorRef)
     (implicit s: Scheduler): Props = {
 
     Props(new BackPressuredWebSocketActor(producer, out))

--- a/server/app/engine/DataProducer.scala
+++ b/server/app/engine/DataProducer.scala
@@ -10,8 +10,6 @@ import scala.concurrent.duration._
 final class DataProducer(interval: FiniteDuration, seed: Long)
   extends Observable[Signal] {
 
-  private case class State(x: Int, y: Int, ts: Long)
-
   override def unsafeSubscribeFn(subscriber: Subscriber[Signal]): Cancelable = {
     import subscriber.{scheduler => s}
 
@@ -21,8 +19,7 @@ final class DataProducer(interval: FiniteDuration, seed: Long)
 
     val generator = random.scan(Signal(0, s.currentTimeMillis())) {
       case (Signal(value, _), rnd) =>
-        val next = value + rnd
-        Signal(next, s.currentTimeMillis())
+        Signal(value + rnd, s.currentTimeMillis())
     }
 
     generator

--- a/server/app/engine/SimpleWebSocketActor.scala
+++ b/server/app/engine/SimpleWebSocketActor.scala
@@ -8,13 +8,12 @@ import monix.execution.Ack.Continue
 import monix.execution.cancelables.CompositeCancelable
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.libs.json.{JsValue, Json, Writes}
-import shared.models.Event
 
 import scala.concurrent.duration._
 import engine.BackPressuredWebSocketActor._
 
 
-class SimpleWebSocketActor[T <: Event : Writes]
+class SimpleWebSocketActor[T: Writes]
   (producer: Observable[T], out: ActorRef)(implicit s: Scheduler)
   extends Actor {
 
@@ -53,7 +52,7 @@ class SimpleWebSocketActor[T <: Event : Writes]
 
 object SimpleWebSocketActor {
   /** Utility for quickly creating a `Props` */
-  def props[T <: Event : Writes](producer: Observable[T], out: ActorRef)
+  def props[T: Writes](producer: Observable[T], out: ActorRef)
     (implicit s: Scheduler): Props = {
 
     Props(new SimpleWebSocketActor(producer, out))


### PR DESCRIPTION
I feel less strongly about the changes I qualified as "arguable".

SimpleWebSocketClient:
1) onComplete is one statement so no braces
2) onError can be writtern in terms of onComplete (_arguable_, admittedly)
3) downstream.onError should use the exception of this file not of "unrelated" 

BackPressuredWebSocketClient, which happens to be in same package ApplicationController:
1) MessageFlowTransformer plays no role because the two type parameters of WebSocket.accept are the same tparam (JsValue); not specifying is along PLAY examples.

BackPressureWebSocketActor + SimpleWebSocketActor: has no dependency on Event for tparam T.

DataProducer:
1) class State is dead code
2) lines 24-25 can be combined into one line and it does not look that hard to follow as a single line (_arguable_).

_Additional comments:_
Interestingly Intellij does not like the registration of callbacks in SimpleWebSocketClient to val (read-only) variables such as webSocket.onopen. I am ignoring this as noise since the code compiles and runs nonetheless.

Could you tell me how to set up a debug/run configuration in Intellij for monix-sample? Normally I know how to do it, but not for this project. It's easier to explore with debug freedom than editing some printlns.